### PR TITLE
presto, using the mysql connector

### DIFF
--- a/docker-init
+++ b/docker-init
@@ -5,3 +5,4 @@ docker-machine start default || echo "Machine is already running";
 ./docker-init-druid
 ./docker-init-mysql
 ./docker-init-postgres
+# ./docker-init-presto

--- a/docker-init-presto
+++ b/docker-init-presto
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+eval $(docker-machine env)
+
+PRESTO_TAG=0.141
+SERV_PORT=8080
+
+echo "Loading Presto..."
+docker rm -f datazoo-presto 2>/dev/null || echo "no Presto container to remove";
+
+docker run -d --name=datazoo-presto --restart=always -h presto -p 8080:8080 \
+  -v "$PWD"/presto/etc:/presto/etc:Z \
+  zhicwu/presto:$PRESTO_TAG

--- a/docker-start
+++ b/docker-start
@@ -6,5 +6,6 @@ eval $(docker-machine env)
 docker start datazoo-druid
 docker start datazoo-mysql
 docker start datazoo-postgres
+# docker start datazoo-presto
 
 echo "Running on: $DOCKER_HOST"

--- a/presto/etc/catalog/mysql.properties
+++ b/presto/etc/catalog/mysql.properties
@@ -1,0 +1,3 @@
+connector.name=mysql
+connection-url=jdbc:mysql://192.168.99.100:3306
+connection-user=root

--- a/presto/etc/config.properties
+++ b/presto/etc/config.properties
@@ -1,0 +1,7 @@
+coordinator=true
+node-scheduler.include-coordinator=true
+query.max-memory=4GB
+query.max-memory-per-node=1GB
+http-server.http.port=8080
+discovery-server.enabled=true
+discovery.uri=http://presto:8080

--- a/presto/etc/jvm.config
+++ b/presto/etc/jvm.config
@@ -1,0 +1,8 @@
+-server
+-Xmx2G
+-XX:+UseG1GC
+-XX:G1HeapRegionSize=32M
+-XX:+UseGCOverheadLimit
+-XX:+ExplicitGCInvokesConcurrent
+-XX:+HeapDumpOnOutOfMemoryError
+-XX:OnOutOfMemoryError=kill -9 0

--- a/presto/etc/log.properties
+++ b/presto/etc/log.properties
@@ -1,0 +1,1 @@
+com.facebook.presto=INFO

--- a/presto/etc/node.properties
+++ b/presto/etc/node.properties
@@ -1,0 +1,3 @@
+node.environment=production
+node.id=f41808b3-34bc-11e6-b18d-a45e60f258d9
+node.data-dir=/presto/data


### PR DESCRIPTION
works, and i have a minimal test case here:

``` js
var presto = require('presto-client');
var prestoClient = new presto.Client({
  host: '192.168.99.100',
  port: 8080,
  catalog: 'mysql',
  schema: 'datazoo'
});

prestoClient.execute(`SELECT COUNT(*) FROM "wikipedia_raw"`, (error, data) => {
  if (error) { console.log(error); return }
  console.log(data)
})
```
