### PR TITLE
add postgres connector for presto

### DIFF
--- a/presto/etc/catalog/postgresql.properties
+++ b/presto/etc/catalog/postgresql.properties
@@ -1,0 +1,4 @@
+connector.name=postgresql
+connection-url=jdbc:postgresql://192.168.99.100:5432/datazoo
+connection-user=root
+connection-password=datazoo


### PR DESCRIPTION
minimal test case:

``` js
var presto = require('presto-client');
var prestoClient = new presto.Client({
  host: '192.168.99.100',
  port: 8080,
  catalog: 'postgresql'
});

prestoClient.execute(`SELECT COUNT(*) FROM wikipedia_raw`, (error, data) => {
  if (error) { console.log(error); return }
  console.log(data)
})
```
